### PR TITLE
Add endpoint to retrieve processed tree structure with error handling

### DIFF
--- a/app/endpoints/anomalies.py
+++ b/app/endpoints/anomalies.py
@@ -261,3 +261,35 @@ async def create_tree_structure(request: CreateStructureRequest):
             "status"     : 200
         }
     )
+
+@router.get("/processed_tree_structure")
+async def get_processed_tree_structure():
+    try:
+        processed_tree_structure = TreeStructure.read_all_json_structure(step="processed")
+        return JSONResponse(
+            status_code=200,
+            content={
+                "response": processed_tree_structure,
+                "success": True,
+                "status": 200
+            }
+        )
+    except FileNotFoundError:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "response": "Processed tree structure not found",
+                "success": False,
+                "status": 404
+            }
+        )
+    except Exception as e:
+        logger.error(f"Failed to get processed tree structure: {e}")
+        return JSONResponse(
+            status_code=500,
+            content={
+                "response": "Failed to get processed tree structure",
+                "success": False,
+                "status": 500
+            }
+        )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new GET API endpoint at /processed_tree_structure to retrieve the latest processed tree structure.
  * Returns a 200 response with the structure in JSON when available.
  * Provides clear error handling: 404 when no processed structure is found and 500 for unexpected errors, with informative messages.
  * Ensures consistent, user-friendly responses for integrating processed structure data into client applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->